### PR TITLE
test: Agregar pruebas unitarias para la clase Catalogo

### DIFF
--- a/src/test/java/biblioteca/CatalogoTest.java
+++ b/src/test/java/biblioteca/CatalogoTest.java
@@ -1,0 +1,45 @@
+package biblioteca;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+class CatalogoTest {
+
+    private Catalogo catalogo;
+    private Libro libro1;
+    private Libro libro2;
+
+    @BeforeEach
+    void setUp() {
+        catalogo = new Catalogo();
+        libro1 = new Libro("978-3-16-148410-0", "Clean Code", "Robert C. Martin");
+        libro2 = new Libro("978-0-13-235088-4", "Clean Architecture", "Robert C. Martin");
+        catalogo.agregarLibro(libro1);
+        catalogo.agregarLibro(libro2);
+    }
+
+    @Test
+    void testBuscarLibroExistentePorIsbn() {
+        Libro encontrado = catalogo.buscarPorIsbn("978-3-16-148410-0");
+        assertNotNull(encontrado);
+        assertEquals("Clean Code", encontrado.getTitulo());
+    }
+
+    @Test
+    void testBuscarLibroInexistentePorIsbn() {
+        Libro encontrado = catalogo.buscarPorIsbn("000-0-00-000000-0");
+        assertNull(encontrado);
+    }
+
+    @Test
+    void testObtenerLibrosDisponibles() {
+        libro1.cambiarEstado(Estado.PRESTADO); // Solo libro2 debería estar disponible
+
+        List<Libro> disponibles = catalogo.obtenerLibrosDisponibles();
+
+        assertEquals(1, disponibles.size());
+        assertEquals("Clean Architecture", disponibles.get(0).getTitulo());
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request - Pruebas unitarias para la clase Catalogo

## 📋 Descripción
Se implementan pruebas unitarias para la clase `Catalogo` utilizando **JUnit5**.

- Se prueba la búsqueda de libros por ISBN.
- Se prueba el listado de libros disponibles.
- Se prueba el comportamiento ante ISBN no existente.

## 📂 Cambios realizados
- Creación de `CatalogoTest.java` bajo el paquete `biblioteca`.

## ✅ Checklist
- [x] Test de búsqueda de libro existente.
- [x] Test de búsqueda de libro inexistente.
- [x] Test de obtención de libros disponibles.

## 🔗 Issue relacionado
Closes #5
